### PR TITLE
node-expat dependency updated.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "prepublish": "coffee -c index.coffee"
   },
   "dependencies": {
-    "node-expat": "2.0.0"
+    "node-expat": "^2.0.0"
   },
   "devDependencies": {
     "mocha": "~1.4.2",
     "coffee-script": "1.6.x"
   },
   "engines": {
-    "node": "0.8.x"
+   
   }
 }


### PR DESCRIPTION
node-expat 2.0.0 doesn't builds in newer version of node.